### PR TITLE
Add Map of Subnets Names to Subnet IDs. Add `tags`. Merge `attributes`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 # Module directory
 .terraform/
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Full example:
 
 ```hcl
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=remove_subnets"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
   namespace  = "${var.namespace}"
   name       = "vpc"
   stage      = "${var.stage}"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # terraform-aws-named-subnets
 
-Terraform module for named `subnets` provisioning.
+Terraform module for named [`subnets`](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html) provisioning.
 
 
 ## Usage
 
 Simple example:
 
-```terraform
+```hcl
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=remove_subnets"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
   namespace  = "${var.namespace}"
   name       = "vpc"
   stage      = "${var.stage}"
@@ -49,7 +49,7 @@ module "private_subnets" {
 
 Full example:
 
-```terraform
+```hcl
 module "vpc" {
   source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=remove_subnets"
   namespace  = "${var.namespace}"
@@ -123,23 +123,23 @@ module "us_east_1b_private_subnets" {
 |:------------------------------|:---------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------:|
 | `namespace`                   | ``                    | Namespace (e.g. `cp` or `cloudposse`)                                                                                                                                                     |   Yes    |
 | `stage`                       | ``                    | Stage (e.g. `prod`, `dev`, `staging`)                                                                                                                                                     |   Yes    |
-| `delimiter`                   | `-`                   | Delimiter to be used between `name`, `namespace`, `stage`, etc.                                                                                                                           |    No    |
+| `delimiter`                   | `-`                   | Delimiter to use between `name`, `namespace`, `stage`, `attributes`.                                                                                                                      |    No    |
 | `attributes`                  | `[]`                  | Additional attributes (e.g. `policy` or `role`)                                                                                                                                           |    No    |
 | `tags`                        | `{}`                  | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                                                                                                                                        |    No    |
 | `names`                       | ``                    | List of subnets names (e.g. `["apples", "oranges", "grapes"]`)                                                                                                                            |   Yes    |
-| `max_subnets`                 | `16`                  | A maximum number of subnets which can be created. This variable is being used for CIDR blocks calculation. MUST be greater than length of `names` list.                                   |    No    |
-| `availability_zone`           | ``                    | An Availability Zone where subnets will be created (e.g. `us-east-1a`).                                                                                                                   |   Yes    |
-| `type`                        | `private`             | A type of subnets (e.g. `private`, or `public`)                                                                                                                                           |    No    |
-| `vpc_id`                      | ``                    | A VPC ID where subnets will be created (e.g. `vpc-aceb2723`). If empty, a new VPC will be created                                                                                         |   Yes    |
-| `cidr_block`                  | ``                    | A base CIDR block which will be divided into subnet CIDR blocks (e.g. `10.0.0.0/24`)                                                                                                      |    No    |
-| `igw_id`                      | ``                    | An Internet Gateway ID which will be used as a default route in public route tables (e.g. `igw-9c26a123`). Conflicts with `ngw_id`                                                        |   Yes    |
-| `ngw_id`                      | ``                    | A NAT Gateway ID which will be used as a default route in private route tables (e.g. `igw-9c26a123`). Conflicts with `igw_id`                                                             |   Yes    |
+| `max_subnets`                 | `16`                  | Maximum number of subnets which can be created. This variable is being used for CIDR blocks calculation. MUST be greater than length of `names` list.                                     |    No    |
+| `availability_zone`           | ``                    | Availability Zone where subnets will be created (e.g. `us-east-1a`).                                                                                                                      |   Yes    |
+| `type`                        | `private`             | Type of subnets (`private` or `public`)                                                                                                                                                   |    No    |
+| `vpc_id`                      | ``                    | VPC ID where subnets will be created (e.g. `vpc-aceb2723`). If empty, a new VPC will be created                                                                                           |   Yes    |
+| `cidr_block`                  | ``                    | Base CIDR block which will be divided into subnet CIDR blocks (e.g. `10.0.0.0/24`)                                                                                                        |    No    |
+| `igw_id`                      | ``                    | Internet Gateway ID which will be used as a default route in public route tables (e.g. `igw-9c26a123`). Conflicts with `ngw_id`                                                           |   Yes    |
+| `ngw_id`                      | ``                    | NAT Gateway ID which will be used as a default route in private route tables (e.g. `igw-9c26a123`). Conflicts with `igw_id`                                                               |   Yes    |
 | `public_network_acl_id`       | ``                    | ID of Network ACL which will be added to the public subnets.  If empty, a new ACL will be created                                                                                         |    No    |
 | `private_network_acl_id`      | ``                    | ID of Network ACL which will be added to the private subnets.  If empty, a new ACL will be created                                                                                        |    No    |
-| `public_network_acl_egress`   | see [variables.tf]    | An Egress ACL which will be added to the new Public Network ACL                                                                                                                           |    No    |
-| `public_network_acl_ingress`  | see [variables.tf]    | An Ingress ACL which will be added to the new Public Network ACL                                                                                                                          |    No    |
-| `private_network_acl_egress`  | see [variables.tf]    | An Egress ACL which will be added to the new Private Network ACL                                                                                                                          |    No    |
-| `private_network_acl_ingress` | see [variables.tf]    | An Ingress ACL which will be added to the new Private Network ACL                                                                                                                         |    No    |
+| `public_network_acl_egress`   | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Egress ACL which will be added to the new Public Network ACL                                          |    No    |
+| `public_network_acl_ingress`  | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Ingress ACL which will be added to the new Public Network ACL                                         |    No    |
+| `private_network_acl_egress`  | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Egress ACL which will be added to the new Private Network ACL                                         |    No    |
+| `private_network_acl_ingress` | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Ingress ACL which will be added to the new Private Network ACL                                        |    No    |
 
 
 ## Outputs
@@ -151,6 +151,7 @@ module "us_east_1b_private_subnets" {
 | ngw_public_ip   | A public IP address of a NAT Gateway         |
 | subnet_ids      | IDs of Subnets                               |
 | route_table_ids | IDs of Route Tables                          |
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ module "public_subnets" {
   source            = "git::https://github.com/cloudposse/terraform-aws-named-subnets.git?ref=master"
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
+  name              = "${var.name}"
   names             = ["apples", "oranges", "grapes"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.public_cidr_block}"
@@ -38,6 +39,7 @@ module "private_subnets" {
   attributes        = ["us-east-1a"]
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
+  name              = "${var.name}"
   names             = ["charlie", "echo", "bravo"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.private_cidr_block}"
@@ -69,6 +71,7 @@ module "us_east_1a_public_subnets" {
   source            = "git::https://github.com/cloudposse/terraform-aws-named-subnets.git?ref=master"
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
+  name              = "${var.name}"
   names             = ["apples", "oranges", "grapes"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.us_east_1a_public_cidr_block}"
@@ -82,6 +85,7 @@ module "us_east_1a_private_subnets" {
   attributes        = ["us-east-1a"]
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
+  name              = "${var.name}"
   names             = ["charlie", "echo", "bravo"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.us_east_1a_private_cidr_block}"
@@ -95,6 +99,7 @@ module "us_east_1b_public_subnets" {
   attributes        = ["us-east-1b"]
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
+  name              = "${var.name}"
   names             = ["apples", "oranges", "grapes"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.us_east_1b_public_cidr_block}"
@@ -108,6 +113,7 @@ module "us_east_1b_private_subnets" {
   attributes        = ["us-east-1b"]
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
+  name              = "${var.name}"
   names             = ["charlie", "echo", "bravo"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.us_east_1b_private_cidr_block}"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform module for named [`subnets`](http://docs.aws.amazon.com/AmazonVPC/late
 
 ## Usage
 
-Simple example:
+Simple example with private and public subnets in one Availability Zone:
 
 ```hcl
 module "vpc" {
@@ -26,7 +26,7 @@ module "public_subnets" {
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
-  names             = ["web1", "web2", "web3"]
+  subnet_names      = ["web1", "web2", "web3"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.public_cidr_block}"
   type              = "public"
@@ -39,7 +39,7 @@ module "private_subnets" {
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
-  names             = ["kafka", "cassandra", "zookeeper"]
+  subnet_names      = ["kafka", "cassandra", "zookeeper"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.private_cidr_block}"
   type              = "private"
@@ -71,7 +71,7 @@ module "us_east_1a_public_subnets" {
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
-  names             = ["apples", "oranges", "grapes"]
+  subnet_names      = ["apples", "oranges", "grapes"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.us_east_1a_public_cidr_block}"
   type              = "public"
@@ -85,7 +85,7 @@ module "us_east_1a_private_subnets" {
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
-  names             = ["charlie", "echo", "bravo"]
+  subnet_names      = ["charlie", "echo", "bravo"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.us_east_1a_private_cidr_block}"
   type              = "private"
@@ -99,7 +99,7 @@ module "us_east_1b_public_subnets" {
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
-  names             = ["apples", "oranges", "grapes"]
+  subnet_names      = ["apples", "oranges", "grapes"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.us_east_1b_public_cidr_block}"
   type              = "public"
@@ -113,7 +113,7 @@ module "us_east_1b_private_subnets" {
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
-  names             = ["charlie", "echo", "bravo"]
+  subnet_names      = ["charlie", "echo", "bravo"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.us_east_1b_private_cidr_block}"
   type              = "private"
@@ -129,11 +129,11 @@ module "us_east_1b_private_subnets" {
 |:------------------------------|:---------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------:|
 | `namespace`                   | ``                    | Namespace (_e.g._ `cp` or `cloudposse`)                                                                                                                                                   |   Yes    |
 | `stage`                       | ``                    | Stage (_e.g._ `prod`, `dev`, `staging`)                                                                                                                                                   |   Yes    |
-| `name`                        | ``                    | Application or solution name (_e.g._ `web`, `app`)                                                                                                                                        |   Yes    |
+| `name`                        | ``                    | Application or solution name (_e.g._ `myapp`)                                                                                                                                        |   Yes    |
 | `delimiter`                   | `-`                   | Delimiter to use between `name`, `namespace`, `stage`, `attributes`                                                                                                                       |    No    |
 | `attributes`                  | `[]`                  | Additional attributes (_e.g._ `policy` or `role`)                                                                                                                                         |    No    |
 | `tags`                        | `{}`                  | Additional tags  (_e.g._ `map("BusinessUnit","XYZ")`                                                                                                                                      |    No    |
-| `names`                       | ``                    | List of subnet names (_e.g._ `["kafka", "cassandra", "zookeeper"]`)                                                                                                                       |   Yes    |
+| `subnet_names`                | ``                    | List of subnet names (_e.g._ `["kafka", "cassandra", "zookeeper"]`)                                                                                                                       |   Yes    |
 | `max_subnets`                 | `16`                  | Maximum number of subnets that can be created. This variable is being used for CIDR blocks calculation. MUST be greater than length of `names` list                                       |    No    |
 | `availability_zone`           | ``                    | Availability Zone where subnets will be created (e.g. `us-east-1a`)                                                                                                                       |   Yes    |
 | `type`                        | `private`             | Type of subnets (`private` or `public`)                                                                                                                                                   |    No    |
@@ -161,7 +161,7 @@ module "us_east_1b_private_subnets" {
 | named_subnet_ids          | Map of subnet names to subnet IDs            |
 
 
-Given the following configuration
+Given the following configuration (see the Simple example above)
 
 ```hcl
 locals {
@@ -174,7 +174,7 @@ module "public_subnets" {
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
-  names             = ["web1", "web2", "web3"]
+  subnet_names      = ["web1", "web2", "web3"]
   vpc_id            = "${var.vpc_id}"
   cidr_block        = "${local.public_cidr_block}"
   type              = "public"
@@ -187,7 +187,7 @@ module "private_subnets" {
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
-  names             = ["kafka", "cassandra", "zookeeper"]
+  subnet_names      = ["kafka", "cassandra", "zookeeper"]
   vpc_id            = "${var.vpc_id}"
   cidr_block        = "${local.private_cidr_block}"
   type              = "private"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ module "private_subnets" {
 }
 ```
 
-Full example:
+Full example, with private and public subnets in two Availability Zones for High Availability:
 
 ```hcl
 module "vpc" {

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ module "us_east_1b_private_subnets" {
 
 | Name            | Description                                  |
 |:----------------|:---------------------------------------------|
-| ngw_id          | ID of NAT Gateway                            |
-| ngw_private_ip  | A private IP address of a NAT Gateway        |
-| ngw_public_ip   | A public IP address of a NAT Gateway         |
+| ngw_id          | NAT Gateway ID                               |
+| ngw_private_ip  | Private IP address of the NAT Gateway        |
+| ngw_public_ip   | Public IP address of the NAT Gateway         |
 | subnet_ids      | IDs of Subnets                               |
 | route_table_ids | IDs of Route Tables                          |
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ module "public_subnets" {
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
-  names             = ["apples", "oranges", "grapes"]
+  names             = ["web1", "web2", "web3"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.public_cidr_block}"
   type              = "public"
@@ -36,11 +36,10 @@ module "public_subnets" {
 
 module "private_subnets" {
   source            = "git::https://github.com/cloudposse/terraform-aws-named-subnets.git?ref=master"
-  attributes        = ["us-east-1a"]
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
-  names             = ["charlie", "echo", "bravo"]
+  names             = ["kafka", "cassandra", "zookeeper"]
   vpc_id            = "${module.vpc.vpc_id}"
   cidr_block        = "${local.private_cidr_block}"
   type              = "private"
@@ -78,11 +77,11 @@ module "us_east_1a_public_subnets" {
   type              = "public"
   igw_id            = "${module.vpc.igw_id}"
   availability_zone = "us-east-1a"
+  attributes        = ["us-east-1a"]
 }
 
 module "us_east_1a_private_subnets" {
   source            = "git::https://github.com/cloudposse/terraform-aws-named-subnets.git?ref=master"
-  attributes        = ["us-east-1a"]
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
@@ -92,11 +91,11 @@ module "us_east_1a_private_subnets" {
   type              = "private"
   availability_zone = "us-east-1a"
   ngw_id            = "${module.us_east_1a_public_subnets.ngw_id}"
+  attributes        = ["us-east-1a"]
 }
 
 module "us_east_1b_public_subnets" {
   source            = "git::https://github.com/cloudposse/terraform-aws-named-subnets.git?ref=master"
-  attributes        = ["us-east-1b"]
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
@@ -106,11 +105,11 @@ module "us_east_1b_public_subnets" {
   type              = "public"
   igw_id            = "${module.vpc.igw_id}"
   availability_zone = "us-east-1b"
+  attributes        = ["us-east-1b"]
 }
 
 module "us_east_1b_private_subnets" {
   source            = "git::https://github.com/cloudposse/terraform-aws-named-subnets.git?ref=master"
-  attributes        = ["us-east-1b"]
   namespace         = "${var.namespace}"
   stage             = "${var.stage}"
   name              = "${var.name}"
@@ -120,6 +119,7 @@ module "us_east_1b_private_subnets" {
   type              = "private"
   availability_zone = "us-east-1b"
   ngw_id            = "${module.us_east_1b_public_subnets.ngw_id}"
+  attributes        = ["us-east-1b"]
 }
 ```
 
@@ -129,34 +129,35 @@ module "us_east_1b_private_subnets" {
 |:------------------------------|:---------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------:|
 | `namespace`                   | ``                    | Namespace (e.g. `cp` or `cloudposse`)                                                                                                                                                     |   Yes    |
 | `stage`                       | ``                    | Stage (e.g. `prod`, `dev`, `staging`)                                                                                                                                                     |   Yes    |
-| `delimiter`                   | `-`                   | Delimiter to use between `name`, `namespace`, `stage`, `attributes`.                                                                                                                      |    No    |
+| `delimiter`                   | `-`                   | Delimiter to use between `name`, `namespace`, `stage`, `attributes`                                                                                                                       |    No    |
 | `attributes`                  | `[]`                  | Additional attributes (e.g. `policy` or `role`)                                                                                                                                           |    No    |
 | `tags`                        | `{}`                  | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                                                                                                                                        |    No    |
-| `names`                       | ``                    | List of subnets names (e.g. `["apples", "oranges", "grapes"]`)                                                                                                                            |   Yes    |
-| `max_subnets`                 | `16`                  | Maximum number of subnets which can be created. This variable is being used for CIDR blocks calculation. MUST be greater than length of `names` list.                                     |    No    |
+| `names`                       | ``                    | List of subnets names (e.g. `["kafka", "cassandra", "zookeeper"]`)                                                                                                                        |   Yes    |
+| `max_subnets`                 | `16`                  | Maximum number of subnets that can be created. This variable is being used for CIDR blocks calculation. MUST be greater than length of `names` list.                                      |    No    |
 | `availability_zone`           | ``                    | Availability Zone where subnets will be created (e.g. `us-east-1a`).                                                                                                                      |   Yes    |
 | `type`                        | `private`             | Type of subnets (`private` or `public`)                                                                                                                                                   |    No    |
-| `vpc_id`                      | ``                    | VPC ID where subnets will be created (e.g. `vpc-aceb2723`). If empty, a new VPC will be created                                                                                           |   Yes    |
+| `vpc_id`                      | ``                    | VPC ID where subnets will be created (e.g. `vpc-aceb2723`)                                                                                                                                |   Yes    |
 | `cidr_block`                  | ``                    | Base CIDR block which will be divided into subnet CIDR blocks (e.g. `10.0.0.0/24`)                                                                                                        |    No    |
-| `igw_id`                      | ``                    | Internet Gateway ID which will be used as a default route in public route tables (e.g. `igw-9c26a123`). Conflicts with `ngw_id`                                                           |   Yes    |
-| `ngw_id`                      | ``                    | NAT Gateway ID which will be used as a default route in private route tables (e.g. `igw-9c26a123`). Conflicts with `igw_id`                                                               |   Yes    |
+| `igw_id`                      | ``                    | Internet Gateway ID which will be used as a default route in public route tables (e.g. `igw-9c26a123`)                                                                                    |   Yes    |
+| `ngw_id`                      | ``                    | NAT Gateway ID which will be used as a default route in private route tables (e.g. `igw-9c26a123`)                                                                                        |   Yes    |
 | `public_network_acl_id`       | ``                    | ID of Network ACL which will be added to the public subnets.  If empty, a new ACL will be created                                                                                         |    No    |
 | `private_network_acl_id`      | ``                    | ID of Network ACL which will be added to the private subnets.  If empty, a new ACL will be created                                                                                        |    No    |
-| `public_network_acl_egress`   | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Egress ACL which will be added to the new Public Network ACL                                          |    No    |
-| `public_network_acl_ingress`  | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Ingress ACL which will be added to the new Public Network ACL                                         |    No    |
-| `private_network_acl_egress`  | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Egress ACL which will be added to the new Private Network ACL                                         |    No    |
-| `private_network_acl_ingress` | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Ingress ACL which will be added to the new Private Network ACL                                        |    No    |
+| `public_network_acl_egress`   | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Egress rules which will be added to the new Public Network ACL                                        |    No    |
+| `public_network_acl_ingress`  | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Ingress rules which will be added to the new Public Network ACL                                       |    No    |
+| `private_network_acl_egress`  | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Egress rules which will be added to the new Private Network ACL                                       |    No    |
+| `private_network_acl_ingress` | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Ingress rules which will be added to the new Private Network ACL                                      |    No    |
 
 
 ## Outputs
 
-| Name            | Description                                  |
-|:----------------|:---------------------------------------------|
-| ngw_id          | NAT Gateway ID                               |
-| ngw_private_ip  | Private IP address of the NAT Gateway        |
-| ngw_public_ip   | Public IP address of the NAT Gateway         |
-| subnet_ids      | IDs of Subnets                               |
-| route_table_ids | IDs of Route Tables                          |
+| Name                      | Description                                  |
+|:--------------------------|:---------------------------------------------|
+| ngw_id                    | NAT Gateway ID                               |
+| ngw_private_ip            | Private IP address of the NAT Gateway        |
+| ngw_public_ip             | Public IP address of the NAT Gateway         |
+| route_table_ids           | Route Table IDs                              |
+| subnet_ids                | Subnet IDs                                   |
+| subnet_names_subnet_ids   | Map of subnet names to subnet IDs            |
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ output "public_subnet_names_subnet_ids" {
 
 the output Maps of subnet names to subnet IDs will look like these
 
-```js
+```json
 public_subnet_names_subnet_ids = {
   web1 = subnet-ea58d78e
   web2 = subnet-556ee131
@@ -218,9 +218,9 @@ private_subnet_names_subnet_ids = {
 }
 ```
 
-and the created subnet IDs could be found by the subnet names using `map["key"]` or [`lookup(map, key, [default])`](https://www.terraform.io/docs/configuration/interpolation.html#lookup-map-key-default-),
+and the created subnet IDs could be found by the subnet names using `map["key"]` or [`lookup(map, key, [default])`](https://www.terraform.io/docs/configuration/interpolation.html#lookup-map-key-default-)
 
-_e.g._
+for example:
 
 `public_subnet_names_subnet_ids["web1"]`
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ output "public_subnet_names_subnet_ids" {
 
 the output Maps of subnet names to subnet IDs will look like these
 
-```json
+```hcl
 public_subnet_names_subnet_ids = {
   web1 = subnet-ea58d78e
   web2 = subnet-556ee131
@@ -218,9 +218,7 @@ private_subnet_names_subnet_ids = {
 }
 ```
 
-and the created subnet IDs could be found by the subnet names using `map["key"]` or [`lookup(map, key, [default])`](https://www.terraform.io/docs/configuration/interpolation.html#lookup-map-key-default-)
-
-for example:
+and the created subnet IDs could be found by the subnet names using `map["key"]` or [`lookup(map, key, [default])`](https://www.terraform.io/docs/configuration/interpolation.html#lookup-map-key-default-), for example:
 
 `public_subnet_names_subnet_ids["web1"]`
 

--- a/README.md
+++ b/README.md
@@ -127,21 +127,22 @@ module "us_east_1b_private_subnets" {
 
 | Name                          | Default               | Description                                                                                                                                                                               | Required |
 |:------------------------------|:---------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------:|
-| `namespace`                   | ``                    | Namespace (e.g. `cp` or `cloudposse`)                                                                                                                                                     |   Yes    |
-| `stage`                       | ``                    | Stage (e.g. `prod`, `dev`, `staging`)                                                                                                                                                     |   Yes    |
+| `namespace`                   | ``                    | Namespace (_e.g._ `cp` or `cloudposse`)                                                                                                                                                   |   Yes    |
+| `stage`                       | ``                    | Stage (_e.g._ `prod`, `dev`, `staging`)                                                                                                                                                   |   Yes    |
+| `name`                        | ``                    | Application or solution name (_e.g._ `web`, `app`)                                                                                                                                        |   Yes    |
 | `delimiter`                   | `-`                   | Delimiter to use between `name`, `namespace`, `stage`, `attributes`                                                                                                                       |    No    |
-| `attributes`                  | `[]`                  | Additional attributes (e.g. `policy` or `role`)                                                                                                                                           |    No    |
-| `tags`                        | `{}`                  | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                                                                                                                                        |    No    |
-| `names`                       | ``                    | List of subnets names (e.g. `["kafka", "cassandra", "zookeeper"]`)                                                                                                                        |   Yes    |
-| `max_subnets`                 | `16`                  | Maximum number of subnets that can be created. This variable is being used for CIDR blocks calculation. MUST be greater than length of `names` list.                                      |    No    |
-| `availability_zone`           | ``                    | Availability Zone where subnets will be created (e.g. `us-east-1a`).                                                                                                                      |   Yes    |
+| `attributes`                  | `[]`                  | Additional attributes (_e.g._ `policy` or `role`)                                                                                                                                         |    No    |
+| `tags`                        | `{}`                  | Additional tags  (_e.g._ `map("BusinessUnit","XYZ")`                                                                                                                                      |    No    |
+| `names`                       | ``                    | List of subnet names (_e.g._ `["kafka", "cassandra", "zookeeper"]`)                                                                                                                       |   Yes    |
+| `max_subnets`                 | `16`                  | Maximum number of subnets that can be created. This variable is being used for CIDR blocks calculation. MUST be greater than length of `names` list                                       |    No    |
+| `availability_zone`           | ``                    | Availability Zone where subnets will be created (e.g. `us-east-1a`)                                                                                                                       |   Yes    |
 | `type`                        | `private`             | Type of subnets (`private` or `public`)                                                                                                                                                   |    No    |
-| `vpc_id`                      | ``                    | VPC ID where subnets will be created (e.g. `vpc-aceb2723`)                                                                                                                                |   Yes    |
-| `cidr_block`                  | ``                    | Base CIDR block which will be divided into subnet CIDR blocks (e.g. `10.0.0.0/24`)                                                                                                        |    No    |
-| `igw_id`                      | ``                    | Internet Gateway ID which will be used as a default route in public route tables (e.g. `igw-9c26a123`)                                                                                    |   Yes    |
-| `ngw_id`                      | ``                    | NAT Gateway ID which will be used as a default route in private route tables (e.g. `igw-9c26a123`)                                                                                        |   Yes    |
-| `public_network_acl_id`       | ``                    | ID of Network ACL which will be added to the public subnets.  If empty, a new ACL will be created                                                                                         |    No    |
-| `private_network_acl_id`      | ``                    | ID of Network ACL which will be added to the private subnets.  If empty, a new ACL will be created                                                                                        |    No    |
+| `vpc_id`                      | ``                    | VPC ID where subnets will be created (_e.g._ `vpc-aceb2723`)                                                                                                                              |   Yes    |
+| `cidr_block`                  | ``                    | Base CIDR block which will be divided into subnet CIDR blocks (_e.g._ `10.0.0.0/24`)                                                                                                      |    No    |
+| `igw_id`                      | ``                    | Internet Gateway ID which will be used as a default route in public route tables (_e.g._ `igw-9c26a123`)                                                                                  |   Yes    |
+| `ngw_id`                      | ``                    | NAT Gateway ID which will be used as a default route in private route tables (_e.g._ `igw-9c26a123`)                                                                                      |   Yes    |
+| `public_network_acl_id`       | ``                    | ID of Network ACL which will be added to the public subnets. If empty, a new ACL will be created                                                                                          |    No    |
+| `private_network_acl_id`      | ``                    | ID of Network ACL which will be added to the private subnets. If empty, a new ACL will be created                                                                                         |    No    |
 | `public_network_acl_egress`   | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Egress rules which will be added to the new Public Network ACL                                        |    No    |
 | `public_network_acl_ingress`  | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Ingress rules which will be added to the new Public Network ACL                                       |    No    |
 | `private_network_acl_egress`  | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)    | Egress rules which will be added to the new Private Network ACL                                       |    No    |
@@ -157,7 +158,7 @@ module "us_east_1b_private_subnets" {
 | ngw_public_ip             | Public IP address of the NAT Gateway         |
 | route_table_ids           | Route Table IDs                              |
 | subnet_ids                | Subnet IDs                                   |
-| subnet_names_subnet_ids   | Map of subnet names to subnet IDs            |
+| named_subnet_ids          | Map of subnet names to subnet IDs            |
 
 
 Given the following configuration
@@ -194,24 +195,24 @@ module "private_subnets" {
   ngw_id            = "${module.public_subnets.ngw_id}"
 }
 
-output "private_subnet_names_subnet_ids" {
-  value = "${module.private_subnets.subnet_names_subnet_ids}"
+output "private_named_subnet_ids" {
+  value = "${module.private_subnets.named_subnet_ids}"
 }
 
-output "public_subnet_names_subnet_ids" {
-  value = "${module.public_subnets.subnet_names_subnet_ids}"
+output "public_named_subnet_ids" {
+  value = "${module.public_subnets.named_subnet_ids}"
 }
 ```
 
 the output Maps of subnet names to subnet IDs will look like these
 
 ```hcl
-public_subnet_names_subnet_ids = {
+public_named_subnet_ids = {
   web1 = subnet-ea58d78e
   web2 = subnet-556ee131
   web3 = subnet-6f54db0b
 }
-private_subnet_names_subnet_ids = {
+private_named_subnet_ids = {
   cassandra = subnet-376de253
   kafka = subnet-9e53dcfa
   zookeeper = subnet-a86fe0cc
@@ -220,9 +221,9 @@ private_subnet_names_subnet_ids = {
 
 and the created subnet IDs could be found by the subnet names using `map["key"]` or [`lookup(map, key, [default])`](https://www.terraform.io/docs/configuration/interpolation.html#lookup-map-key-default-), for example:
 
-`public_subnet_names_subnet_ids["web1"]`
+`public_named_subnet_ids["web1"]`
 
-`lookup(private_subnet_names_subnet_ids, "kafka")`
+`lookup(private_named_subnet_ids, "kafka")`
 
 
 ## License

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,19 +5,20 @@ output "ngw_id" {
 
 output "ngw_private_ip" {
   value       = "${join("", aws_nat_gateway.default.*.private_ip)}"
-  description = "Private IP addresse of the NAT Gateway"
+  description = "Private IP address of the NAT Gateway"
 }
 
 output "ngw_public_ip" {
   value       = "${join("", aws_nat_gateway.default.*.public_ip)}"
-  description = "Public IP addresse of the NAT Gateway"
+  description = "Public IP address of the NAT Gateway"
 }
 
 output "subnet_ids" {
   value       = ["${coalescelist(aws_subnet.private.*.id, aws_subnet.public.*.id)}"]
-  description = "IDs of private subnets"
+  description = "Subnets IDs"
 }
 
 output "route_table_ids" {
-  value = ["${coalescelist(aws_route_table.public.*.id, aws_route_table.private.*.id)}"]
+  value       = ["${coalescelist(aws_route_table.public.*.id, aws_route_table.private.*.id)}"]
+  description = "Route Table IDs"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,5 +24,5 @@ output "route_table_ids" {
 }
 
 output "named_subnet_ids" {
-  value = "${zipmap(var.names, matchkeys(coalescelist(aws_subnet.private.*.id, aws_subnet.public.*.id), coalescelist(aws_subnet.private.*.tags.Named, aws_subnet.public.*.tags.Named), var.names))}"
+  value = "${zipmap(var.subnet_names, matchkeys(coalescelist(aws_subnet.private.*.id, aws_subnet.public.*.id), coalescelist(aws_subnet.private.*.tags.Named, aws_subnet.public.*.tags.Named), var.subnet_names))}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,10 +15,14 @@ output "ngw_public_ip" {
 
 output "subnet_ids" {
   value       = ["${coalescelist(aws_subnet.private.*.id, aws_subnet.public.*.id)}"]
-  description = "Subnets IDs"
+  description = "Subnet IDs"
 }
 
 output "route_table_ids" {
   value       = ["${coalescelist(aws_route_table.public.*.id, aws_route_table.private.*.id)}"]
   description = "Route Table IDs"
+}
+
+output "subnet_names_subnet_ids" {
+  value = "${zipmap(var.names, matchkeys(coalescelist(aws_subnet.private.*.id, aws_subnet.public.*.id), coalescelist(aws_subnet.private.*.tags.Named, aws_subnet.public.*.tags.Named), var.names))}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,6 @@ output "route_table_ids" {
   description = "Route Table IDs"
 }
 
-output "subnet_names_subnet_ids" {
+output "named_subnet_ids" {
   value = "${zipmap(var.names, matchkeys(coalescelist(aws_subnet.private.*.id, aws_subnet.public.*.id), coalescelist(aws_subnet.private.*.tags.Named, aws_subnet.public.*.tags.Named), var.names))}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,16 +1,16 @@
 output "ngw_id" {
   value       = "${join("", aws_nat_gateway.default.*.id)}"
-  description = "IDs of NAT Gateways"
+  description = "NAT Gateway ID"
 }
 
 output "ngw_private_ip" {
   value       = "${join("", aws_nat_gateway.default.*.private_ip)}"
-  description = "The private IP addresses of the NAT Gateways"
+  description = "Private IP addresse of the NAT Gateway"
 }
 
 output "ngw_public_ip" {
   value       = "${join("", aws_nat_gateway.default.*.public_ip)}"
-  description = "The public IP addresses of the NAT Gateways"
+  description = "Public IP addresse of the NAT Gateway"
 }
 
 output "subnet_ids" {

--- a/private.tf
+++ b/private.tf
@@ -18,6 +18,7 @@ resource "aws_subnet" "private" {
     "Name"      = "${module.private_label.id}${var.delimiter}${element(var.names, count.index)}"
     "Stage"     = "${module.private_label.stage}"
     "Namespace" = "${module.private_label.namespace}"
+    "Named"     = "${element(var.names, count.index)}"
   }
 }
 

--- a/private.tf
+++ b/private.tf
@@ -9,40 +9,40 @@ module "private_label" {
 }
 
 resource "aws_subnet" "private" {
-  count             = "${var.type == "private" ? length(var.names) : 0}"
+  count             = "${var.type == "private" ? length(var.subnet_names) : 0}"
   vpc_id            = "${var.vpc_id}"
   availability_zone = "${var.availability_zone}"
   cidr_block        = "${cidrsubnet(var.cidr_block, ceil(log(var.max_subnets, 2)), count.index)}"
 
   tags = {
-    "Name"      = "${module.private_label.id}${var.delimiter}${element(var.names, count.index)}"
+    "Name"      = "${module.private_label.id}${var.delimiter}${element(var.subnet_names, count.index)}"
     "Stage"     = "${module.private_label.stage}"
     "Namespace" = "${module.private_label.namespace}"
-    "Named"     = "${element(var.names, count.index)}"
+    "Named"     = "${element(var.subnet_names, count.index)}"
     "Type"      = "${var.type}"
   }
 }
 
 resource "aws_route_table" "private" {
-  count  = "${var.type == "private" ? length(var.names) : 0}"
+  count  = "${var.type == "private" ? length(var.subnet_names) : 0}"
   vpc_id = "${var.vpc_id}"
 
   tags = {
-    "Name"      = "${module.private_label.id}${var.delimiter}${element(var.names, count.index)}"
+    "Name"      = "${module.private_label.id}${var.delimiter}${element(var.subnet_names, count.index)}"
     "Stage"     = "${module.private_label.stage}"
     "Namespace" = "${module.private_label.namespace}"
   }
 }
 
 resource "aws_route" "private" {
-  count                  = "${var.type == "private" ? length(var.names) : 0}"
+  count                  = "${var.type == "private" ? length(var.subnet_names) : 0}"
   route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
   nat_gateway_id         = "${var.ngw_id}"
   destination_cidr_block = "0.0.0.0/0"
 }
 
 resource "aws_route_table_association" "private" {
-  count          = "${var.type == "private" ? length(var.names) : 0}"
+  count          = "${var.type == "private" ? length(var.subnet_names) : 0}"
   subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
   route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
 }

--- a/private.tf
+++ b/private.tf
@@ -1,7 +1,7 @@
 module "private_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.2"
   namespace  = "${var.namespace}"
-  name       = "${var.availability_zone}"
+  name       = "${var.name}"
   stage      = "${var.stage}"
   delimiter  = "${var.delimiter}"
   tags       = "${var.tags}"

--- a/private.tf
+++ b/private.tf
@@ -19,6 +19,7 @@ resource "aws_subnet" "private" {
     "Stage"     = "${module.private_label.stage}"
     "Namespace" = "${module.private_label.namespace}"
     "Named"     = "${element(var.names, count.index)}"
+    "Type"      = "${var.type}"
   }
 }
 

--- a/private.tf
+++ b/private.tf
@@ -2,10 +2,10 @@ module "private_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.2"
   namespace  = "${var.namespace}"
   name       = "${var.availability_zone}"
-  attributes = ["private"]
   stage      = "${var.stage}"
   delimiter  = "${var.delimiter}"
   tags       = "${var.tags}"
+  attributes = ["${compact(concat(var.attributes, list("private")))}"]
 }
 
 resource "aws_subnet" "private" {

--- a/public.tf
+++ b/public.tf
@@ -9,40 +9,40 @@ module "public_label" {
 }
 
 resource "aws_subnet" "public" {
-  count             = "${var.type == "public" ? length(var.names) : 0}"
+  count             = "${var.type == "public" ? length(var.subnet_names) : 0}"
   vpc_id            = "${var.vpc_id}"
   availability_zone = "${var.availability_zone}"
   cidr_block        = "${cidrsubnet(var.cidr_block, ceil(log(var.max_subnets, 2)), count.index)}"
 
   tags = {
-    "Name"      = "${module.public_label.id}${var.delimiter}${element(var.names, count.index)}"
+    "Name"      = "${module.public_label.id}${var.delimiter}${element(var.subnet_names, count.index)}"
     "Stage"     = "${module.public_label.stage}"
     "Namespace" = "${module.public_label.namespace}"
-    "Named"     = "${element(var.names, count.index)}"
+    "Named"     = "${element(var.subnet_names, count.index)}"
     "Type"      = "${var.type}"
   }
 }
 
 resource "aws_route_table" "public" {
-  count  = "${var.type == "public" ? length(var.names) : 0}"
+  count  = "${var.type == "public" ? length(var.subnet_names) : 0}"
   vpc_id = "${var.vpc_id}"
 
   tags = {
-    "Name"      = "${module.public_label.id}${var.delimiter}${element(var.names, count.index)}"
+    "Name"      = "${module.public_label.id}${var.delimiter}${element(var.subnet_names, count.index)}"
     "Stage"     = "${module.public_label.stage}"
     "Namespace" = "${module.public_label.namespace}"
   }
 }
 
 resource "aws_route" "public" {
-  count                  = "${var.type == "public" ? length(var.names) : 0}"
+  count                  = "${var.type == "public" ? length(var.subnet_names) : 0}"
   route_table_id         = "${element(aws_route_table.public.*.id, count.index)}"
   gateway_id             = "${var.igw_id}"
   destination_cidr_block = "0.0.0.0/0"
 }
 
 resource "aws_route_table_association" "public" {
-  count          = "${var.type == "public" ? length(var.names) : 0}"
+  count          = "${var.type == "public" ? length(var.subnet_names) : 0}"
   subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
   route_table_id = "${element(aws_route_table.public.*.id, count.index)}"
 }

--- a/public.tf
+++ b/public.tf
@@ -19,6 +19,7 @@ resource "aws_subnet" "public" {
     "Stage"     = "${module.public_label.stage}"
     "Namespace" = "${module.public_label.namespace}"
     "Named"     = "${element(var.names, count.index)}"
+    "Type"      = "${var.type}"
   }
 }
 

--- a/public.tf
+++ b/public.tf
@@ -1,7 +1,7 @@
 module "public_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.2"
   namespace  = "${var.namespace}"
-  name       = "${var.availability_zone}"
+  name       = "${var.name}"
   stage      = "${var.stage}"
   delimiter  = "${var.delimiter}"
   tags       = "${var.tags}"

--- a/public.tf
+++ b/public.tf
@@ -2,10 +2,10 @@ module "public_label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.2"
   namespace  = "${var.namespace}"
   name       = "${var.availability_zone}"
-  attributes = ["public"]
   stage      = "${var.stage}"
   delimiter  = "${var.delimiter}"
   tags       = "${var.tags}"
+  attributes = ["${compact(concat(var.attributes, list("public")))}"]
 }
 
 resource "aws_subnet" "public" {

--- a/public.tf
+++ b/public.tf
@@ -18,6 +18,7 @@ resource "aws_subnet" "public" {
     "Name"      = "${module.public_label.id}${var.delimiter}${element(var.names, count.index)}"
     "Stage"     = "${module.public_label.stage}"
     "Namespace" = "${module.public_label.namespace}"
+    "Named"     = "${element(var.names, count.index)}"
   }
 }
 

--- a/public.tf
+++ b/public.tf
@@ -67,6 +67,7 @@ resource "aws_nat_gateway" "default" {
   count         = "${var.type == "public" ? 1 : 0}"
   allocation_id = "${join("", aws_eip.default.*.id)}"
   subnet_id     = "${element(aws_subnet.public.*.id, 0)}"
+  tags          = "${module.public_label.tags}"
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -31,9 +31,9 @@ variable "tags" {
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
-variable "names" {
+variable "subnet_names" {
   type        = "list"
-  description = "List of subnets names (e.g. `['apples', 'oranges', 'grapes']`)"
+  description = "List of subnet names (e.g. `['apples', 'oranges', 'grapes']`)"
 }
 
 variable "max_subnets" {
@@ -51,7 +51,7 @@ variable "availability_zone" {
 }
 
 variable "vpc_id" {
-  description = "VPC Id"
+  description = "VPC ID"
 }
 
 variable "cidr_block" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "stage" {
 variable "delimiter" {
   type        = "string"
   default     = "-"
-  description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
+  description = "Delimiter to be used between `name`, `namespace`, `stage`, `attributes`"
 }
 
 variable "attributes" {
@@ -32,13 +32,13 @@ variable "names" {
 }
 
 variable "max_subnets" {
-  default = "16"
-  description = "A maximum number of subnets which can be created. This variable is being used for CIDR blocks calculation. Default to length of `names` argument"
+  default     = "16"
+  description = "Maximum number of subnets which can be created. This variable is being used for CIDR blocks calculation. Default to length of `names` argument"
 }
 
 variable "type" {
   default     = "private"
-  description = "The type of subnets (e.g. `private`, or `public`)"
+  description = "Type of subnets (e.g. `private`, or `public`)"
 }
 
 variable "availability_zone" {
@@ -46,20 +46,20 @@ variable "availability_zone" {
 }
 
 variable "vpc_id" {
-  description = "ID of VPC"
+  description = "VPC Id"
 }
 
 variable "cidr_block" {
-  description = "The base CIDR block which will be divided into subnet CIDR blocks (e.g. `10.0.0.0/16`)"
+  description = "Base CIDR block which will be divided into subnet CIDR blocks (e.g. `10.0.0.0/16`)"
 }
 
 variable "igw_id" {
-  description = "The Internet Gateway ID which will be used as a default route in public route tables (e.g. `igw-9c26a123`). Conflicts with `ngw_id`"
+  description = "Internet Gateway ID which will be used as a default route in public route tables (e.g. `igw-9c26a123`). Conflicts with `ngw_id`"
   default     = ""
 }
 
 variable "ngw_id" {
-  description = "The NAT Gateway ID which will be used as a default route in private route tables (e.g. `igw-9c26a123`). Conflicts with `igw_id`"
+  description = "NAT Gateway ID which will be used as a default route in private route tables (e.g. `igw-9c26a123`). Conflicts with `igw_id`"
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "max_subnets" {
 
 variable "type" {
   default     = "private"
-  description = "Type of subnets (e.g. `private`, or `public`)"
+  description = "Type of subnets (`private` or `public`)"
 }
 
 variable "availability_zone" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "stage" {
   type        = "string"
 }
 
+variable "name" {
+  type        = "string"
+  description = "Application or solution name"
+}
+
 variable "delimiter" {
   type        = "string"
   default     = "-"


### PR DESCRIPTION
## what
* Updated `README`
* Merged `attributes`
* Added `tags`
* Added `named_subnet_ids` output

## why
* We need to merge `attributes` to propagate them from top-level modules
* Propagate `tags` from top-level modules to tag AWS resources
* The purpose of the module is to create named subnets and be able to find the subnet IDs by the subnet names. The `named_subnet_ids` output is the Map of Subnet Names to Subnet IDs

## test
Given the following configuration

```hcl
locals {
  public_cidr_block  = "${cidrsubnet(var.vpc_cidr, 1, 0)}"
  private_cidr_block = "${cidrsubnet(var.vpc_cidr, 1, 1)}"
}

module "public_subnets" {
  source            = "git::https://github.com/cloudposse/terraform-aws-named-subnets.git?ref=master"
  namespace         = "${var.namespace}"
  stage             = "${var.stage}"
  name              = "${var.name}"
  names             = ["web1", "web2", "web3"]
  vpc_id            = "${var.vpc_id}"
  cidr_block        = "${local.public_cidr_block}"
  type              = "public"
  availability_zone = "us-east-1a"
  igw_id            = "${var.igw_id}"
}

module "private_subnets" {
  source            = "git::https://github.com/cloudposse/terraform-aws-named-subnets.git?ref=master"
  namespace         = "${var.namespace}"
  stage             = "${var.stage}"
  name              = "${var.name}"
  names             = ["kafka", "cassandra", "zookeeper"]
  vpc_id            = "${var.vpc_id}"
  cidr_block        = "${local.private_cidr_block}"
  type              = "private"
  availability_zone = "us-east-1a"
  ngw_id            = "${module.public_subnets.ngw_id}"
}

output "private_named_subnet_ids" {
  value = "${module.private_subnets.subnet_names_subnet_ids}"
}

output "public_named_subnet_ids" {
  value = "${module.public_subnets.subnet_names_subnet_ids}"
}
```

the output Maps of subnet names to subnet IDs look like these

```hcl
public_named_subnet_ids = {
  web1 = subnet-ea58d78e
  web2 = subnet-556ee131
  web3 = subnet-6f54db0b
}
private_named_subnet_ids = {
  cassandra = subnet-376de253
  kafka = subnet-9e53dcfa
  zookeeper = subnet-a86fe0cc
}
```

and the created subnet IDs could be found by the subnet names using `map["key"]` or [`lookup(map, key, [default])`](https://www.terraform.io/docs/configuration/interpolation.html#lookup-map-key-default-), for example:

`public_named_subnet_ids["web1"]`

`lookup(private_named_subnet_ids, "kafka")`
