### PR TITLE
Add option to set `ENI` as a default route for private subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,30 @@ module "private_subnets" {
 }
 ```
 
+Simple example, with `ENI` as default route gateway for private subnets
+
+```terraform
+resource "aws_network_interface" "default" {
+  subnet_id         = "${module.us_east_1b_public_subnets.subnet_ids[0]}"
+  source_dest_check = "false"
+  tags              = "${module.network_interface_label.id}
+}
+
+module "us_east_1b_private_subnets" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-named-subnets.git?ref=master"
+  namespace         = "${var.namespace}"
+  stage             = "${var.stage}"
+  name              = "${var.name}"
+  subnet_names      = ["charlie", "echo", "bravo"]
+  vpc_id            = "${module.vpc.vpc_id}"
+  cidr_block        = "${local.us_east_1b_private_cidr_block}"
+  type              = "private"
+  availability_zone = "us-east-1b"
+  eni_id            = "${aws_network_interface.default.id}"
+  attributes        = ["us-east-1b"]
+}
+```
+
 Full example, with private and public subnets in two Availability Zones for High Availability:
 
 ```terraform

--- a/README.md
+++ b/README.md
@@ -121,34 +121,59 @@ module "us_east_1b_private_subnets" {
   ngw_id            = "${module.us_east_1b_public_subnets.ngw_id}"
   attributes        = ["us-east-1b"]
 }
+
+resource "aws_network_interface" "default" {
+  subnet_id         = "${module.us_east_1b_public_subnets.subnet_ids[0]}"
+  source_dest_check = "false"
+  tags              = "${module.network_interface_label.id}
+}
+
+module "us_east_1b_private_subnets" {
+  source            = "git::https://github.com/cloudposse/terraform-aws-named-subnets.git?ref=master"
+  namespace         = "${var.namespace}"
+  stage             = "${var.stage}"
+  name              = "${var.name}"
+  subnet_names      = ["charlie", "echo", "bravo"]
+  vpc_id            = "${module.vpc.vpc_id}"
+  cidr_block        = "${local.us_east_1b_private_cidr_block}"
+  type              = "private"
+  availability_zone = "us-east-1b"
+  eni_id            = "${aws_network_interface.default.id}"
+  attributes        = ["us-east-1b"]
+}
+
 ```
+
+## Caveat
+You must use only one type of device for a default route gateway per route table. `ENI` or `NGW`
 
 # Inputs
 
-| Name                          |                                                Default                                                 | Description                                                                                                                                         | Required |
-|:------------------------------|:------------------------------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------|:--------:|
-| `namespace`                   |                                                   ``                                                   | Namespace (_e.g._ `cp` or `cloudposse`)                                                                                                             |   Yes    |
-| `stage`                       |                                                   ``                                                   | Stage (_e.g._ `prod`, `dev`, `staging`)                                                                                                             |   Yes    |
-| `name`                        |                                                   ``                                                   | Application or solution name (_e.g._ `myapp`)                                                                                                       |   Yes    |
-| `delimiter`                   |                                                  `-`                                                   | Delimiter to use between `name`, `namespace`, `stage`, `attributes`                                                                                 |    No    |
-| `attributes`                  |                                                  `[]`                                                  | Additional attributes (_e.g._ `policy` or `role`)                                                                                                   |    No    |
-| `tags`                        |                                                  `{}`                                                  | Additional tags  (_e.g._ `map("BusinessUnit","XYZ")`                                                                                                |    No    |
-| `subnet_names`                |                                                   ``                                                   | List of subnet names (_e.g._ `["kafka", "cassandra", "zookeeper"]`)                                                                                 |   Yes    |
-| `max_subnets`                 |                                                  `16`                                                  | Maximum number of subnets that can be created. This variable is being used for CIDR blocks calculation. MUST be greater than length of `names` list |    No    |
-| `availability_zone`           |                                                   ``                                                   | Availability Zone where subnets are created (_e.g._ `us-east-1a`)                                                                                   |   Yes    |
-| `type`                        |                                               `private`                                                | Type of subnets (`private` or `public`)                                                                                                             |    No    |
-| `vpc_id`                      |                                                   ``                                                   | VPC ID where subnets are created (_e.g._ `vpc-aceb2723`)                                                                                            |   Yes    |
-| `cidr_block`                  |                                                   ``                                                   | Base CIDR block which is divided into subnet CIDR blocks (_e.g._ `10.0.0.0/24`)                                                                     |    No    |
-| `igw_id`                      |                                                   ``                                                   | Internet Gateway ID which is used as a default route in public route tables (_e.g._ `igw-9c26a123`)                                                 |   Yes    |
-| `ngw_id`                      |                                                   ``                                                   | NAT Gateway ID which is used as a default route in private route tables (_e.g._ `igw-9c26a123`)                                                     |   Yes    |
-| `public_network_acl_id`       |                                                   ``                                                   | ID of Network ACL which is added to the public subnets. If empty, a new ACL will be created                                                         |    No    |
-| `private_network_acl_id`      |                                                   ``                                                   | ID of Network ACL which is added to the private subnets. If empty, a new ACL will be created                                                        |    No    |
-| `public_network_acl_egress`   | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf) | Egress rules which will be added to the new Public Network ACL                                                                                      |    No    |
-| `public_network_acl_ingress`  | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf) | Ingress rules which will be added to the new Public Network ACL                                                                                     |    No    |
-| `private_network_acl_egress`  | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf) | Egress rules which will be added to the new Private Network ACL                                                                                     |    No    |
-| `private_network_acl_ingress` | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf) | Ingress rules which will be added to the new Private Network ACL                                                                                    |    No    |
-| `enabled`                     |                                                 `true`                                                 | Set to `false` to prevent the module from creating any resources                                                                                    |    No    |
-| `nat_enabled`                 |                                                 `true`                                                 | Set to `false` if NAT Gateway is not required in `public` subnet                                                                                    |    No    |
+| Name                            | Default                                                                                                  | Description                                                                                                                                           | Required   |
+| :------------------------------ | :------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------- | :--------: |
+| `namespace`                     | ``                                                                                                       | Namespace (_e.g._ `cp` or `cloudposse`)                                                                                                               | Yes        |
+| `stage`                         | ``                                                                                                       | Stage (_e.g._ `prod`, `dev`, `staging`)                                                                                                               | Yes        |
+| `name`                          | ``                                                                                                       | Application or solution name (_e.g._ `myapp`)                                                                                                         | Yes        |
+| `delimiter`                     | `-`                                                                                                      | Delimiter to use between `name`, `namespace`, `stage`, `attributes`                                                                                   | No         |
+| `attributes`                    | `[]`                                                                                                     | Additional attributes (_e.g._ `policy` or `role`)                                                                                                     | No         |
+| `tags`                          | `{}`                                                                                                     | Additional tags  (_e.g._ `map("BusinessUnit","XYZ")`                                                                                                  | No         |
+| `subnet_names`                  | ``                                                                                                       | List of subnet names (_e.g._ `["kafka", "cassandra", "zookeeper"]`)                                                                                   | Yes        |
+| `max_subnets`                   | `16`                                                                                                     | Maximum number of subnets that can be created. This variable is being used for CIDR blocks calculation. MUST be greater than length of `names` list   | No         |
+| `availability_zone`             | ``                                                                                                       | Availability Zone where subnets are created (_e.g._ `us-east-1a`)                                                                                     | Yes        |
+| `type`                          | `private`                                                                                                | Type of subnets (`private` or `public`)                                                                                                               | No         |
+| `vpc_id`                        | ``                                                                                                       | VPC ID where subnets are created (_e.g._ `vpc-aceb2723`)                                                                                              | Yes        |
+| `cidr_block`                    | ``                                                                                                       | Base CIDR block which is divided into subnet CIDR blocks (_e.g._ `10.0.0.0/24`)                                                                       | No         |
+| `igw_id`                        | ``                                                                                                       | Internet Gateway ID which is used as a default route in public route tables (_e.g._ `igw-9c26a123`)                                                   | Yes        |
+| `ngw_id`                        | ``                                                                                                       | NAT Gateway ID which is used as a default route in private route tables (_e.g._ `igw-9c26a123`)                                                       | Yes        |
+| `eni_id`                        | ``                                                                                                       | An ID of a network interface which is used as a default route in private route tables (_e.g._ `eni-9c26a123`)                                         | Yes        |
+| `public_network_acl_id`         | ``                                                                                                       | ID of Network ACL which is added to the public subnets. If empty, a new ACL will be created                                                           | No         |
+| `private_network_acl_id`        | ``                                                                                                       | ID of Network ACL which is added to the private subnets. If empty, a new ACL will be created                                                          | No         |
+| `public_network_acl_egress`     | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)   | Egress rules which will be added to the new Public Network ACL                                                                                        | No         |
+| `public_network_acl_ingress`    | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)   | Ingress rules which will be added to the new Public Network ACL                                                                                       | No         |
+| `private_network_acl_egress`    | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)   | Egress rules which will be added to the new Private Network ACL                                                                                       | No         |
+| `private_network_acl_ingress`   | see [variables.tf](https://github.com/cloudposse/terraform-aws-named-subnets/blob/master/variables.tf)   | Ingress rules which will be added to the new Private Network ACL                                                                                      | No         |
+| `enabled`                       | `true`                                                                                                   | Set to `false` to prevent the module from creating any resources                                                                                      | No         |
+| `nat_enabled`                   | `true`                                                                                                   | Set to `false` if NAT Gateway is not required in `public` subnet                                                                                      | No         |
 
 ## Outputs
 

--- a/private.tf
+++ b/private.tf
@@ -42,6 +42,7 @@ resource "aws_route_table" "private" {
 resource "aws_route" "private" {
   count                  = "${local.private_count}"
   route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
+  network_interface_id   = "${var.eni_id}"
   nat_gateway_id         = "${var.ngw_id}"
   destination_cidr_block = "0.0.0.0/0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -151,3 +151,7 @@ variable "nat_enabled" {
   description = "Flag of creation NAT Gateway"
   default     = "true"
 }
+
+variable "eni_id" {
+  default = ""
+}


### PR DESCRIPTION
## What
* Add option to set `ENI` as a default route for private subnets

## Why
* We need option to set custom default route


## Plan
![image](https://user-images.githubusercontent.com/1134449/32897726-077b3cac-caef-11e7-93c8-31c0b3a3c2ad.png)
