### PR TITLE
Add map_public_ip_on_launch variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -340,6 +341,7 @@ Available targets:
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
 | eni\_id | An ID of a network interface which is used as a default route in private route tables (\_e.g.\_ `eni-9c26a123`) | `string` | `""` | no |
 | igw\_id | Internet Gateway ID which will be used as a default route in public route tables (e.g. `igw-9c26a123`). Conflicts with `ngw_id` | `string` | `""` | no |
+| map\_public\_ip\_on\_launch\_enabled | Enable/disable map\_public\_ip\_on\_launch subnet attribute. | `bool` | `false` | no |
 | max\_subnets | Maximum number of subnets which can be created. This variable is being used for CIDR blocks calculation. Defaults to length of `subnet_names` argument | `number` | `16` | no |
 | name | Application or solution name | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
@@ -368,6 +370,7 @@ Available targets:
 | route\_table\_ids | Route table IDs |
 | subnet\_ids | Subnet IDs |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -23,6 +24,7 @@
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
 | eni\_id | An ID of a network interface which is used as a default route in private route tables (\_e.g.\_ `eni-9c26a123`) | `string` | `""` | no |
 | igw\_id | Internet Gateway ID which will be used as a default route in public route tables (e.g. `igw-9c26a123`). Conflicts with `ngw_id` | `string` | `""` | no |
+| map\_public\_ip\_on\_launch\_enabled | Enable/disable map\_public\_ip\_on\_launch subnet attribute. | `bool` | `false` | no |
 | max\_subnets | Maximum number of subnets which can be created. This variable is being used for CIDR blocks calculation. Defaults to length of `subnet_names` argument | `number` | `16` | no |
 | name | Application or solution name | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
@@ -51,3 +53,4 @@
 | route\_table\_ids | Route table IDs |
 | subnet\_ids | Subnet IDs |
 
+<!-- markdownlint-restore -->

--- a/private.tf
+++ b/private.tf
@@ -14,10 +14,11 @@ module "private_label" {
 }
 
 resource "aws_subnet" "private" {
-  count             = local.private_count
-  vpc_id            = var.vpc_id
-  availability_zone = var.availability_zone
-  cidr_block        = cidrsubnet(var.cidr_block, ceil(log(var.max_subnets, 2)), count.index)
+  count                   = local.private_count
+  vpc_id                  = var.vpc_id
+  availability_zone       = var.availability_zone
+  cidr_block              = cidrsubnet(var.cidr_block, ceil(log(var.max_subnets, 2)), count.index)
+  map_public_ip_on_launch = var.map_public_ip_on_launch_enabled
 
   tags = merge({
     "Name"      = "${module.private_label.id}${var.delimiter}${element(var.subnet_names, count.index)}"

--- a/public.tf
+++ b/public.tf
@@ -15,10 +15,11 @@ module "public_label" {
 }
 
 resource "aws_subnet" "public" {
-  count             = local.public_count
-  vpc_id            = var.vpc_id
-  availability_zone = var.availability_zone
-  cidr_block        = cidrsubnet(var.cidr_block, ceil(log(var.max_subnets, 2)), count.index)
+  count                   = local.public_count
+  vpc_id                  = var.vpc_id
+  availability_zone       = var.availability_zone
+  cidr_block              = cidrsubnet(var.cidr_block, ceil(log(var.max_subnets, 2)), count.index)
+  map_public_ip_on_launch = var.map_public_ip_on_launch_enabled
 
   tags = merge({
     "Name"      = "${module.public_label.id}${var.delimiter}${element(var.subnet_names, count.index)}"

--- a/variables.tf
+++ b/variables.tf
@@ -202,3 +202,9 @@ variable "eni_id" {
   default     = ""
   description = "An ID of a network interface which is used as a default route in private route tables (_e.g._ `eni-9c26a123`)"
 }
+
+variable "map_public_ip_on_launch_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable/disable map_public_ip_on_launch subnet attribute."
+}


### PR DESCRIPTION
## what
* Support `map_public_ip_on_launch` for public subnets

## why
* This is most useful when deploying public subnets with `nat_enabled = false`

