### PR TITLE
Change AWS provider dependency condition

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws  = "~> 2.0"
+    aws  = ">= 2.0"
     null = "~> 2.0"
   }
 }


### PR DESCRIPTION
## what
* Change AWS provider dependency condition operator

## why
* Pessimistic constraint causes conflict when people want to use newer provider version 


## references
* NA

