### PR TITLE
update to v3 of aws and null providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
-| null | ~> 2.0 |
+| aws | ~> 3.0 |
+| null | ~> 3.0 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws  = "~> 2.0"
-    null = "~> 2.0"
+    aws  = "~> 3.0"
+    null = "~> 3.0"
   }
 }


### PR DESCRIPTION
## what
Update aws and null providers to v3

## why
My organization was running into issues recently with regard to VPC endpoint changes outlined here:
https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/445
https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/571

Upgrading to v3 caused no noticeable issues with the module or my vpc resources, but did allow us to upgrade our parent repo provider to v3 (which fixed our issue).
