### PR TITLE
add transit gateway id option to the route table

### DIFF
--- a/private.tf
+++ b/private.tf
@@ -39,6 +39,7 @@ resource "aws_route" "private" {
   route_table_id         = aws_route_table.private.*.id[count.index]
   network_interface_id   = var.eni_id == "" ? null : var.eni_id
   nat_gateway_id         = var.ngw_id == "" ? null : var.ngw_id
+  transit_gateway_id     = var.tgw_id == "" ? null : var.tgw_id
   destination_cidr_block = "0.0.0.0/0"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,12 @@ variable "ngw_id" {
   default     = ""
 }
 
+variable "tgw_id" {
+  type        = string
+  description = "Transit Gateway ID which will be used to route private route tables to a transit gateway."
+  default     = ""
+}
+
 variable "public_network_acl_id" {
   type        = string
   description = "Network ACL ID that will be added to the subnets. If empty, a new ACL will be created "


### PR DESCRIPTION
## what

- The existing module only allows a user to associate the route table of a private subnet with a network interface or a nat gateway.
- By adding the tgw_id argument, users of the subnet module can automatically create a route table with routing between a private subnet and a transit gateway.

## why

- As a best practice, a user may create an AWS account for centralized networking.
- To allow traffic to route from account B to account A (centralized networking account), a Transit Gateway is needed.
- If a user creates a subnet using this module, the tgw_id feature will allow the user to directly associate the route table in the private subnet to an existing transit gateway.
- Example architecture:
         ec2 -> private subnet rtb -> tgw -> private subnet rtb-> natgw -> public internet
         |--------AWS Account B------|-------AWS Account A----------|

## References
[Multi account practices](https://docs.aws.amazon.com/prescriptive-guidance/latest/transitioning-to-multiple-aws-accounts/network-connectivity.html)
