### PR TITLE
fix: update aws_eip to use domain instead of deprecated vpc argument

### DIFF
--- a/public.tf
+++ b/public.tf
@@ -86,8 +86,8 @@ resource "aws_network_acl" "public" {
 }
 
 resource "aws_eip" "default" {
-  count = local.ngw_count
-  vpc   = "true"
+  count  = local.ngw_count
+  domain = "vpc"
 
   lifecycle {
     create_before_destroy = true

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 5.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## what

- Change vpc = "true" to domain = "vpc" in aws_eip resource (public.tf)
- Update AWS provider version constraint to >= 5.0 (versions.tf)

The vpc argument was removed in AWS provider 5.0.0 in favor of domain.

## why

- In order to change another cloudposse module [terraform-aws-mwaa](https://github.com/cloudposse/terraform-aws-mwaa/issues/73), this module needed to be fixed to work with hashicorp AWS v5+.
- This fixes a small incompatibility.
- I also realize this module is deprecated. But the replacement module linked would require extensive refactoring for our use-case, so this is the easiest path forward for now.

## references

- https://github.com/cloudposse/terraform-aws-mwaa/issues/73